### PR TITLE
tweak metadata in "Encrypt password"

### DIFF
--- a/machines/check-password.js
+++ b/machines/check-password.js
@@ -24,6 +24,7 @@ module.exports = {
 
     encryptedPassword: {
       example: 'as34hafsu#w34ndcarok',
+      friendlyName: 'Already-encrypted password hash',
       description: 'The existing (already-encrypted) password hash to compare against.',
       whereToGet: {
         description: 'Look up the already-encrypted password hash stored for this user in your database.',

--- a/machines/check-password.js
+++ b/machines/check-password.js
@@ -4,10 +4,11 @@ module.exports = {
   friendlyName: 'Check password',
 
 
-  description: 'Compare a plaintext password attempt against an already-encrypted version.',
+  description: 'Compare a plaintext password attempt against an already-encrypted Bcrypt hash.',
 
 
-  extendedDescription: 'Useful for checking a password attempt against the stored, already-encrypted BCrypt hash.',
+  extendedDescription: 'Useful for checking a password attempt against the stored, already-encrypted BCrypt hash, '+
+  'e.g. stored in your database.',
 
 
   sideEffects: 'cacheable',
@@ -24,6 +25,9 @@ module.exports = {
     encryptedPassword: {
       example: 'as34hafsu#w34ndcarok',
       description: 'The existing (already-encrypted) password hash to compare against.',
+      whereToGet: {
+        description: 'Use the "Encrypt password" machine to encrypt/hash a password.',
+      },
       required: true,
     }
 
@@ -33,7 +37,7 @@ module.exports = {
   exits: {
 
     success: {
-      description: 'Password attempt matched already-encrypted version.'
+      description: 'Password attempt matched the already-encrypted version.'
     },
 
     incorrect: {

--- a/machines/check-password.js
+++ b/machines/check-password.js
@@ -1,7 +1,7 @@
 module.exports = {
 
 
-  friendlyName: 'Check password',
+  friendlyName: 'Check password attempt',
 
 
   description: 'Compare a plaintext password attempt against an already-encrypted Bcrypt hash.',
@@ -26,7 +26,11 @@ module.exports = {
       example: 'as34hafsu#w34ndcarok',
       description: 'The existing (already-encrypted) password hash to compare against.',
       whereToGet: {
-        description: 'Use the "Encrypt password" machine to encrypt/hash a password.',
+        description: 'Look up the already-encrypted password hash stored for this user in your database.',
+        extendedDescription: 'For example, when a user signs up, your route could use the "Encrypt password" machine '+
+        'to perform one-way encryption on their password.  This uses the BCrypt algorithm, to generate a secure '+
+        'password "hash" that you can then safely store in your database (i.e. when you create a new record for the '+
+        'user in your User model.)',
       },
       required: true,
     }

--- a/machines/check-password.js
+++ b/machines/check-password.js
@@ -23,15 +23,15 @@ module.exports = {
     },
 
     encryptedPassword: {
-      example: 'as34hafsu#w34ndcarok',
-      friendlyName: 'Already-encrypted password hash',
-      description: 'The existing (already-encrypted) password hash to compare against.',
+      example: '2$a492.abc3fadifhoi3hesdqd',
+      friendlyName: 'Encrypted password (hash)',
+      description: 'An existing, already-encrypted password hash to compare against.',
       whereToGet: {
-        description: 'Look up the already-encrypted password hash stored for this user in your database.',
+        description: 'Look up the encrypted password hash stored for this user in your database.',
         extendedDescription: 'For example, when a user signs up, your route could use the "Encrypt password" machine '+
-        'to perform one-way encryption on their password.  This uses the BCrypt algorithm, to generate a secure '+
-        'password "hash" that you can then safely store in your database (i.e. when you create a new record for the '+
-        'user in your User model.)',
+        'to perform one-way (irreversible) encryption on their password.  This uses the BCrypt algorithm to generate a '+
+        'secure, encrypted password hash, which you could then go on to include in a new record in your User model.  '+
+        'This encrypted password hash is much safer to store in your database than a raw, unencrypted password would be.'
       },
       required: true,
     }

--- a/machines/encrypt-password.js
+++ b/machines/encrypt-password.js
@@ -23,7 +23,7 @@ module.exports = {
 
     password: {
       example: 'l0lcatzz',
-      description: 'String to be encrypted.',
+      description: 'The password to be irreversibly encrypted.',
       required: true,
     }
 
@@ -33,9 +33,9 @@ module.exports = {
   exits: {
 
     success: {
-      outputFriendlyName: 'Encrypted password',
+      outputFriendlyName: 'Encrypted password (hash)',
       outputExample: '2$a492.abc3fadifhoi3hesdqd',
-      outputDescription: 'The encrypted version of the input password.'
+      outputDescription: 'The encrypted password hash generated from the provided password.'
     },
 
   },

--- a/machines/encrypt-password.js
+++ b/machines/encrypt-password.js
@@ -4,10 +4,14 @@ module.exports = {
   friendlyName: 'Encrypt password',
 
 
-  description: 'Encrypt a string using the BCrypt algorithm.',
+  description: 'Encrypt/hash a password using the BCrypt algorithm.',
 
 
-  extendedDescription: 'This is particularly useful for encrypting user passwords before storing them in the database.',
+  extendedDescription: 'The BCrypt algorithm is _one-way_-- in other words, passwords hashed/encrypted this way '+
+  '_cannot be decrypted_.  This is ideal for encrypting user passwords before storing them in the database.',
+  
+  
+  moreInfoUrl: 'https://en.wikipedia.org/wiki/Bcrypt',
 
 
   sideEffects: 'cacheable',

--- a/machines/encrypt-password.js
+++ b/machines/encrypt-password.js
@@ -4,11 +4,13 @@ module.exports = {
   friendlyName: 'Encrypt password',
 
 
-  description: 'Encrypt/hash a password using the BCrypt algorithm.',
+  description: 'Perform one-way encryption on a password using the BCrypt algorithm.',
 
 
-  extendedDescription: 'The BCrypt algorithm is _one-way_-- in other words, passwords hashed/encrypted this way '+
-  '_cannot be decrypted_.  This is ideal for encrypting user passwords before storing them in the database.',
+  extendedDescription: 'The BCrypt algorithm is _one-way_-- in other words, passwords encrypted (aka "hashed") this way '+
+  '_cannot be decrypted_.  This is ideal for encrypting user passwords before storing them in the database, for example '+
+  'when a new user signs up for an account.  To _check_ a password attempt, for example when an existing user tries to '+
+  'sign in, use **Check password attempt**.',
   
   
   moreInfoUrl: 'https://en.wikipedia.org/wiki/Bcrypt',


### PR DESCRIPTION
The word "encrypt" is more familiar and friendly, and we should keep it--but we should also add a caveat (see https://github.com/balderdashy/sails-docs/pull/747#issuecomment-244513324).  This adds that.
