### PR TITLE
Change bcrypt-nodejs with bcryptjs

### DIFF
--- a/machines/check-password.js
+++ b/machines/check-password.js
@@ -54,8 +54,8 @@ module.exports = {
 
   fn: function(inputs, exits) {
 
-    // Import native `bcrypt` module.
-    var bcrypt = require('bcrypt-nodejs');
+    // Import pure js `bcrypt` module.
+    var bcrypt = require('bcryptjs');
 
     // Run `compare` to compare the plaintext and encrypted passwords
     // in constant time.

--- a/machines/encrypt-password.js
+++ b/machines/encrypt-password.js
@@ -52,7 +52,7 @@ module.exports = {
     // Import pure js `bcrypt` module.
     var bcrypt = require('bcryptjs');
 
-    let iterations = inputs.depth || 10;
+    var iterations = inputs.depth || 10;
 
     //Get some salt base on iterations
     bcrypt.genSalt(iterations, function(err, salt) {

--- a/machines/encrypt-password.js
+++ b/machines/encrypt-password.js
@@ -25,6 +25,12 @@ module.exports = {
       example: 'l0lcatzz',
       description: 'The password to be irreversibly encrypted.',
       required: true,
+    },
+
+    depth: {
+      example: 10,
+      description: 'The hash number of iterations to apply',
+      required: false
     }
 
   },
@@ -43,19 +49,24 @@ module.exports = {
 
   fn: function(inputs, exits) {
 
-    // Import native `bcrypt` module.
-    var bcrypt = require('bcrypt-nodejs');
+    // Import pure js `bcrypt` module.
+    var bcrypt = require('bcryptjs');
 
-    // Hash the plaintext password.
-    bcrypt.hash(inputs.password, null , null, function(err, hash) {
+    let iterations = inputs.depth || 10;
 
-      // Forward any errors to our `error` exit.
-      if (err) {
-        return exits.error(err);
-      }
+    //Get some salt base on iterations
+    bcrypt.genSalt(iterations, function(err, salt) {
+      // Hash the plaintext password.
+      bcrypt.hash(inputs.password, salt, function(err, hash) {
 
-      // Return the hashed password through the `success` exit.
-      return exits.success(hash);
+        // Forward any errors to our `error` exit.
+        if (err) {
+          return exits.error(err);
+        }
+
+        // Return the hashed password through the `success` exit.
+        return exits.success(hash);
+      });
     });
   }
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "license": "MIT",
   "dependencies": {
     "bcryptjs": "^2.3.0",
+    "chai": "^3.5.0",
     "machine": "^13.0.0-0"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "author": "Mike McNeil",
   "license": "MIT",
   "dependencies": {
-    "bcrypt-nodejs": "0.0.3",
+    "bcryptjs": "^2.3.0",
     "machine": "^13.0.0-0"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.3.0",
   "description": "Encrypt or compare passwords.",
   "scripts": {
-    "test": "node ./node_modules/test-machinepack-mocha/bin/testmachinepack-mocha.js && mocha tests/** -R spec"
+    "test": "node ./node_modules/test-machinepack-mocha/bin/testmachinepack-mocha.js && mocha tests/*.js"
   },
   "keywords": [
     "Passwords",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   "license": "MIT",
   "dependencies": {
     "bcryptjs": "^2.3.0",
-    "chai": "^3.5.0",
     "machine": "^13.0.0-0"
   },
   "repository": {
@@ -31,6 +30,7 @@
   },
   "devDependencies": {
     "mocha": "^3.0.0",
-    "test-machinepack-mocha": "^2.1.1"
+    "test-machinepack-mocha": "^2.1.1",
+    "chai": "^3.5.0"
   }
 }

--- a/tests/encrypt-password.js
+++ b/tests/encrypt-password.js
@@ -46,4 +46,36 @@ describe('machinepack-passwords :: encrypt-password', function() {
 
   });
 
+  it ('should encrypt a string with default iteration number into a password that will have same iteration number information', function(done) {
+
+    var password = "what do you call a frog that that got turned inside out";
+    Passwords.encryptPassword({
+      password: password,
+      // depth: 10
+    }).exec({
+      error: done,
+      success: function(encryptedPassword) {
+        assert.match(encryptedPassword, /^\$2[a-zA-Z]\$10\$/, 'encryption depth matches');
+        done();
+      }
+    });
+
+  });
+
+  it ('should encrypt a string with custom iteration number into a password that will have same iteration number information', function(done) {
+
+    var password = "what do you call a frog that that got turned inside out";
+    Passwords.encryptPassword({
+      password: password,
+      depth: 5
+    }).exec({
+      error: done,
+      success: function(encryptedPassword) {
+        assert.match(encryptedPassword, /^\$2[a-zA-Z]\$0?5\$/, 'encryption depth matches');
+        done();
+      }
+    });
+
+  });
+
 });

--- a/tests/encrypt-password.js
+++ b/tests/encrypt-password.js
@@ -23,4 +23,26 @@ describe('machinepack-passwords :: encrypt-password', function() {
 
   });
 
+  it ('should encrypt a string with custom iteration number into a password that will match the unencrypted version', function(done) {
+
+    var password = "what do you call a frog that that got turned inside out";
+    Passwords.encryptPassword({
+      password: password,
+      depth: 5
+    }).exec({
+      error: done,
+      success: function(encryptedPassword) {
+        Passwords.checkPassword({
+          passwordAttempt: password,
+          encryptedPassword: encryptedPassword
+        }).exec({
+          success: done,
+          incorrect: function() {return done(new Error('Triggered the `incorrect` exit!'));},
+          error: done
+        });
+      }
+    });
+
+  });
+
 });

--- a/tests/encrypt-password.js
+++ b/tests/encrypt-password.js
@@ -1,3 +1,4 @@
+var assert = require('chai').assert;
 var Passwords = require('../');
 
 describe('machinepack-passwords :: encrypt-password', function() {


### PR DESCRIPTION
- Replace old and barely maintainned [bcrypt-nodejs](https://www.npmjs.com/package/bcrypt-nodejs) with popular [bcryptjs](https://github.com/dcodeIO/bcrypt.js).

- Add a "depth" optional parameter (defaulting to *10*) to allow specify number of iterations.

- Add some tests.